### PR TITLE
chore: update contract interface links to deployments repo

### DIFF
--- a/docs/deployed_contracts/botanix.md
+++ b/docs/deployed_contracts/botanix.md
@@ -1,0 +1,10 @@
+# Botanix
+
+## v0.7.1-alpha
+
+Contracts, addresses, and interfaces deployed on Botanix Testnet
+
+| Name                            | Address                                                                                      | Interface |
+|---------------------------------|--------------------------------------------------------------------------------------------| ------------- |
+| Ammalgam Factory               | [`0x0A4a2cD639206b1c2372EFe35a45a8E7d9465c51`](https://testnet.botanixscan.io/address/0x0A4a2cD639206b1c2372EFe35a45a8E7d9465c51) | [IAmmalgamFactory](https://github.com/Ammalgam-Protocol/deployments/blob/main/interfaces/factories/IAmmalgamFactory.sol)
+| Ammalgam Peripheral            | [`0xC867e7989555FcF6a1dDb3EEDe1Fe3d67E383F56`](https://testnet.botanixscan.io/address/0xC867e7989555FcF6a1dDb3EEDe1Fe3d67E383F56) | [IPeripheral](https://github.com/Ammalgam-Protocol/deployments/blob/main/interfaces/IPeripheral.sol)

--- a/docs/deployed_contracts/monad.md
+++ b/docs/deployed_contracts/monad.md
@@ -1,0 +1,10 @@
+# Monad
+
+## v0.7.1-alpha
+
+Contracts, addresses, and interfaces deployed on Monad Testnet
+
+| Name                            | Address                                                                                      | Interface |
+|---------------------------------|--------------------------------------------------------------------------------------------| ------------- |
+| Ammalgam Factory               | [`0x0A4a2cD639206b1c2372EFe35a45a8E7d9465c51`](https://testnet.monadexplorer.com/address/0x0A4a2cD639206b1c2372EFe35a45a8E7d9465c51) | [IAmmalgamFactory](https://github.com/Ammalgam-Protocol/deployments/blob/main/interfaces/factories/IAmmalgamFactory.sol)
+| Ammalgam Peripheral            | [`0xaBA9457bf3670a1Bf5843EFC4b0B6Ad48747f3e8`](https://testnet.monadexplorer.com/address/0xaBA9457bf3670a1Bf5843EFC4b0B6Ad48747f3e8) | [IPeripheral](https://github.com/Ammalgam-Protocol/deployments/blob/main/interfaces/IPeripheral.sol)

--- a/docs/deployed_contracts/sepolia.md
+++ b/docs/deployed_contracts/sepolia.md
@@ -1,10 +1,10 @@
 # Sepolia
 
+## v0.7.1-alpha
+
 Contracts, addresses, and interfaces deployed on Sepolia
 
 | Name                            | Address                                                                                      | Interface |
 |---------------------------------|--------------------------------------------------------------------------------------------| ------------- |
-| Ammalgam Factory               | [`0xBd68dbE675d0d1108af3aEbC5F7724Cf31c82E9a`](https://sepolia.etherscan.io/address/0xBd68dbE675d0d1108af3aEbC5F7724Cf31c82E9a) | [IAmmalgamFactory](https://github.com/Ammalgam-Protocol/core-v1/blob/8a7f458eaa44bd6bb81314db98899ee7d35f8c57/contracts/interfaces/factories/IAmmalgamFactory.sol)
-| Ammalgam Peripheral            | [`0x65dfBe3f4ebaEE887D0188fB42c674Cf6087b0FE`](https://sepolia.etherscan.io/address/0x65dfBe3f4ebaEE887D0188fB42c674Cf6087b0FE) | [IPeripheral](https://github.com/Ammalgam-Protocol/peripheral-v1/blob/master/contracts/interfaces/IPeripheral.sol)
-
-----
+| Ammalgam Factory               | [`0xBd68dbE675d0d1108af3aEbC5F7724Cf31c82E9a`](https://sepolia.etherscan.io/address/0xBd68dbE675d0d1108af3aEbC5F7724Cf31c82E9a) | [IAmmalgamFactory](https://github.com/Ammalgam-Protocol/deployments/blob/main/interfaces/factories/IAmmalgamFactory.sol)
+| Ammalgam Peripheral            | [`0x65dfBe3f4ebaEE887D0188fB42c674Cf6087b0FE`](https://sepolia.etherscan.io/address/0x65dfBe3f4ebaEE887D0188fB42c674Cf6087b0FE) | [IPeripheral](https://github.com/Ammalgam-Protocol/deployments/blob/main/interfaces/IPeripheral.sol)


### PR DESCRIPTION
### Description
- [x] Created new repo [`deployments`](https://github.com/Ammalgam-Protocol/deployments) which has latest `v0.7.1-alpha` contracts deployed addresses, ABIs and interfaces

Fixes: #54 

### TODO:
- [x] Add `Monad` and `Botanix` testnet contract addresses